### PR TITLE
Give mods+ force teamspeak command and save warrants

### DIFF
--- a/Awesome/Functions/player_functions.sqf
+++ b/Awesome/Functions/player_functions.sqf
@@ -424,7 +424,7 @@ player_load_warrants = {
 	if (isNil "_reasons") exitWith {};
 
 	{
-		[player,_x,10000] call player_update_warrants;
+		[player,_x,0] call player_update_warrants;
 	} foreach _reasons;
 
 	[player,_bounty] call player_update_bounty;

--- a/Awesome/Functions/player_functions.sqf
+++ b/Awesome/Functions/player_functions.sqf
@@ -86,12 +86,12 @@ player_pmc = {
 
 count_side = {
 	_side = _this select 0;
-	
+
 	_count = 0;
 	{
 		_player_variable_name = _x;
 		_player_variable = missionNamespace getVariable _player_variable_name;
-		
+
 		if(!isNil "_player_variable") then {
 			if ([_player_variable] call player_exists) then {
 				if ([_player_variable] call player_side == _side) then {
@@ -100,7 +100,7 @@ count_side = {
 			};
 		};
 	} count PlayerStringArray;
-	
+
 	_count
 };
 
@@ -396,6 +396,39 @@ player_reset_warrants = {
 	if (isCiv && ister) then {
 		ister = false;
 	};
+};
+
+player_save_warrants = {
+	private ["_reasons","_bounty"];
+
+	_warrant = [];
+	_reasons = [player] call player_get_reason;
+	_bounty = [player] call player_get_bounty;
+	_warrant = [_bounty,_reasons];
+	_warrant
+};
+
+player_load_warrants = {
+	private ["_warrants","_bounty","_reasons"];
+	_warrants = _this select 0;
+
+	if (isNil "_warrants") exitWith {};
+	if !(count _warrants > 0) exitWith {};
+
+	_bounty = _warrants select 0;
+	_reasons = _warrants select 1;
+
+	if !(count _reasons > 0) exitWith {};
+
+	if (isNil "_bounty") exitWith {};
+	if (isNil "_reasons") exitWith {};
+
+	{
+		[player,_x,10000] call player_update_warrants;
+	} foreach _reasons;
+
+	[player,_bounty] call player_update_bounty;
+
 };
 
 player_armed = {
@@ -1430,7 +1463,7 @@ player_set_gear = {
 		} else {
 			if ([_player] call player_opfor) then {
 				_magazines = OpforGear_Mags;
-				_weapons = OpforGear_Weap;	
+				_weapons = OpforGear_Weap;
 			};
 		};*/
 	};
@@ -2136,10 +2169,10 @@ player_init_arrays = {
 		"ins1","ins2","ins3","ins4","ins9","ins10",
 		"ins11","ins12"
 	];
-	
+
 	PlayerStringArray = CivStringArray + BluStringArray + OpfStringArray + InsStringArray;
 	/* End Factions */
-	
+
 	/* Slots */
 	DogSlots = ["ins3", "cop5"];
 	PMCSlots = ["civ60", "civ61", "civ62", "civ63", "civ64"];
@@ -2147,12 +2180,12 @@ player_init_arrays = {
 	AdmSlots = DogSlots + [];
 	SupSlots = [];
 	VipSlots = [];
-	
+
 	/* References */
 	BluRankReferenceArray = ["cop1"];
 	OpfRankReferenceArray = ["opf1"];
 	OpfRadarReferenceArray = ["opf2"];
-	
+
 	/* System */
 	role = _player;
 	rolestring = toLower(str(_player));
@@ -2163,16 +2196,16 @@ player_init_arrays = {
 	isOpf = (rolestring in OpfStringArray); //[_player] call player_opfor;
 	isIns = (rolestring in InsStringArray); //[_player] call player_insurgent;
 	isCiv = (rolestring in CivStringArray); //[_player] call player_civilian;
-	
+
 	isDog = (rolestring in DogSlots); //[_player] call player_dog;
 	isPmc = (rolestring in PMCSlots); //[_player] call player_pmc;
-	
+
 	isGov = isBlu || isOpf;
 
 	isBluforRanked = (rolestring in BluRankReferenceArray);
 	isOpforRanked = (rolestring in OpfRankReferenceArray);
 	isOpforRadar = (rolestring in OpfRadarReferenceArray);
-	
+
 	isSupSlot = (rolestring in SupSlots);
 	isVipSlot = (rolestring in VipSlots);
 	isAdmSlot = (rolestring in AdmSlots);

--- a/RG/cLoad.sqf
+++ b/RG/cLoad.sqf
@@ -118,7 +118,8 @@ switch (playerSide) do
 		[player, _uid, "WeaponsPlayerCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "LicensesCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "InventoryCiv", "ARRAY"] call sendToServer;
-    	[player, _uid, "privateStorageCiv", "ARRAY"] call sendToServer;
+    		[player, _uid, "privateStorageCiv", "ARRAY"] call sendToServer;
+		[player, _uid, "WarrantsCiv", "ARRAY", _cid] call sendToServer;
 		[player, _uid, "FactoryCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "positionPlayerCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "BackpackPlayerCiv", "STRING"] call sendToServer;

--- a/RG/cLoad.sqf
+++ b/RG/cLoad.sqf
@@ -119,7 +119,7 @@ switch (playerSide) do
 		[player, _uid, "LicensesCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "InventoryCiv", "ARRAY"] call sendToServer;
     		[player, _uid, "privateStorageCiv", "ARRAY"] call sendToServer;
-		[player, _uid, "WarrantsCiv", "ARRAY", _cid] call sendToServer;
+		[player, _uid, "WarrantsCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "FactoryCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "positionPlayerCiv", "ARRAY"] call sendToServer;
 		[player, _uid, "BackpackPlayerCiv", "STRING"] call sendToServer;

--- a/RG/pSave.sqf
+++ b/RG/pSave.sqf
@@ -54,7 +54,7 @@ while {true} do
 			["positionPlayerCiv", ASLtoATL (getPosASL player)], ["BackpackPlayerCiv", typeOf unitBackpack player],
 			["BackWepPlayerCiv", getWeaponCargo (unitBackpack player)], ["BackMagPlayerCiv", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
 			[_uid, "MagazinesPlayerCiv", magazines player] call fn_SaveToServer; sleep 0.1;
-			[getPlayerUID player, getPlayerUID player, "WarrantsCiv", [] call player_save_warrants] call fn_SaveToServer;
+			[_uid, "WarrantsCiv", [] call player_save_warrants] call fn_SaveToServer;
 			if(count INV_LicenseOwner > 0) then {
 				[	_uid,
 					["privateStorageCiv", ([player, "private_storage"] call player_get_array)],

--- a/RG/pSave.sqf
+++ b/RG/pSave.sqf
@@ -9,7 +9,7 @@ while {true} do
 		sleep 120;
 		saveinprogress = true;
 		player groupChat " [STATS SAVING] DO NOT EXIT ";
-		case west: 
+		case west:
 		{
 			[_uid, ["moneyAccountWest", ([player] call get_bank_valuez)], ["InventoryWest", ([player] call player_get_inventory)], ["positionPlayerWest", ASLtoATL (getPosASL player)], ["BackpackPlayerWest", typeOf unitBackpack player], ["BackWepPlayerWest", getWeaponCargo (unitBackpack player)], ["BackMagPlayerWest", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
 			[_uid, "MagazinesPlayerWest", ((magazines player) - ["15Rnd_9x19_M9SD"])] call fn_SaveToServer; sleep 0.1;
@@ -21,7 +21,7 @@ while {true} do
 			};
 			player groupChat " [STATS SAVED] ";
 		};
-		
+
 		case east:
 		{
 			[_uid, ["moneyAccountEast", ([player] call get_bank_valuez)], ["InventoryEast", ([player] call player_get_inventory)], ["positionPlayerEast", ASLtoATL (getPosASL player)], ["BackpackPlayerEast", typeOf unitBackpack player], ["BackWepPlayerEast", getWeaponCargo (unitBackpack player)], ["BackMagPlayerEast", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
@@ -33,7 +33,7 @@ while {true} do
 				[_uid, ["privateStorageEast", ([player, "private_storage"] call player_get_array)], ["WeaponsPlayerEast", weapons player]] call fn_SaveAggToServer; sleep 0.1;
 			};			player groupChat " [STATS SAVED] ";
 		};
-		
+
 		case resistance:
 		{
 			[_uid, ["moneyAccountRes", ([player] call get_bank_valuez)], ["InventoryRes", ([player] call player_get_inventory)], ["positionPlayerRes", ASLtoATL (getPosASL player)], ["BackpackPlayerRes", typeOf unitBackpack player], ["BackWepPlayerRes", getWeaponCargo (unitBackpack player)], ["BackMagPlayerRes", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
@@ -46,21 +46,30 @@ while {true} do
 			};
 			player groupChat " [STATS SAVED] ";
 		};
-		
+
 		case civilian:
 		{
-			[_uid, ["moneyAccountCiv", ([player] call get_bank_valuez)], ["InventoryCiv", ([player] call player_get_inventory)], ["positionPlayerCiv", ASLtoATL (getPosASL player)], ["BackpackPlayerCiv", typeOf unitBackpack player], ["BackWepPlayerCiv", getWeaponCargo (unitBackpack player)], ["BackMagPlayerCiv", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
+			[_uid, ["moneyAccountCiv", ([player] call get_bank_valuez)],
+			["InventoryCiv", ([player] call player_get_inventory)],
+			["positionPlayerCiv", ASLtoATL (getPosASL player)], ["BackpackPlayerCiv", typeOf unitBackpack player],
+			["BackWepPlayerCiv", getWeaponCargo (unitBackpack player)], ["BackMagPlayerCiv", getMagazineCargo (unitBackpack player)]] call fn_SaveAggToServer; sleep 0.1;
 			[_uid, "MagazinesPlayerCiv", magazines player] call fn_SaveToServer; sleep 0.1;
+			[getPlayerUID player, getPlayerUID player, "WarrantsCiv", [] call player_save_warrants] call fn_SaveToServer;
 			if(count INV_LicenseOwner > 0) then {
-				[_uid, ["privateStorageCiv", ([player, "private_storage"] call player_get_array)], ["LicensesCiv", INV_LicenseOwner], ["WeaponsPlayerCiv", weapons player], ["FactoryCiv", INV_Fabrikowner]] call fn_SaveAggToServer; sleep 0.1;
+				[	_uid,
+					["privateStorageCiv", ([player, "private_storage"] call player_get_array)],
+					["LicensesCiv", INV_LicenseOwner],
+					["WeaponsPlayerCiv", weapons player],
+					["FactoryCiv", INV_Fabrikowner]
+				] call fn_SaveAggToServer; sleep 0.1;
 			}
 			else {
 				[_uid, ["privateStorageCiv", ([player, "private_storage"] call player_get_array)], ["WeaponsPlayerCiv", weapons player]] call fn_SaveAggToServer; sleep 0.1;
 			};
 			player groupChat " [STATS SAVED] ";
 		};
-		
-	
+
+
 	};
 	saveinprogress = false;
 };

--- a/RG/sLoad.sqf
+++ b/RG/sLoad.sqf
@@ -10,19 +10,19 @@ _loadFromDBClient =
 	_varName = _array select 1;
 	_varValue = _array select 2;
 	_success = _array select 3;
-	
+
 	if(playerSide == west) then {
 		if(_success) then {
 			if(_varName == 'moneyAccountWest') then {
 				player commandChat format ['Bank account West found. Loading!'];
-				[player, _varValue] call set_bank_valuez; 
+				[player, _varValue] call set_bank_valuez;
 				bankstatsareloaded = true;
 			};
-			
+
 			if(typeName _varValue == 'ARRAY') then {
 				if(count _varValue != 0) then {
 					if(_varName == 'MagazinesplayerWest') then {{player addMagazine _x} forEach _varValue;};
-					if(_varName == 'WeaponsplayerWest') then {{player addWeapon _x} forEach _varValue;};		
+					if(_varName == 'WeaponsplayerWest') then {{player addWeapon _x} forEach _varValue;};
 					if(_varName == 'LicensesWest') then {INV_LicenseOwner = _varValue;};
 					if(_varName == 'InventoryWest') then {[player, _varValue] call player_set_inventory;};
 					if(_varName == 'privateStorageWest') then {[player,'private_storage', _varValue] call player_set_array;};
@@ -32,26 +32,26 @@ _loadFromDBClient =
 					if(_varName == 'BackMagPlayerWest') then {{unitBackpack player addMagazineCargoGlobal [(_varValue select 0) select _forEachIndex, (_varValue select 1) select _forEachIndex];} forEach (_varValue select 0);};
 				};
 			};
-			
+
 			if(typeName _varValue == 'STRING') then {
 				if(_varName == 'BackpackPlayerWest' && _varValue != '<NULL-object>') then {player addBackpack _varValue;};
 			};
 		};
 	};
-	
+
 	if(playerSide == east) then {
 		if(_success) then {
 			if(_varName == 'moneyAccountEast') then {
 				player commandChat format ['Bank account East found. Loading!'];
-				[player, _varValue] call set_bank_valuez; 
+				[player, _varValue] call set_bank_valuez;
 				bankstatsareloaded = true;
 			};
-			
+
 			if(typeName _varValue == 'ARRAY') then {
 				if(count _varValue != 0) then {
 					if(_varName == 'LicensesEast' && count _varValue > 0) then {INV_LicenseOwner = _varValue;};
 					if(_varName == 'InventoryEast') then {[player, _varValue] call player_set_inventory;};
-					if(_varName == 'WeaponsplayerEast') then {{player addWeapon _x} forEach _varValue;};	
+					if(_varName == 'WeaponsplayerEast') then {{player addWeapon _x} forEach _varValue;};
 					if(_varName == 'MagazinesplayerEast') then {{player addMagazine _x} forEach _varValue;};
 					if(_varName == 'privateStorageEast') then {[player, 'private_storage', _varValue] call player_set_array;};
 					if(_varName == 'FactoryEast') then {INV_Fabrikowner = _varValue;};
@@ -60,25 +60,25 @@ _loadFromDBClient =
 					if(_varName == 'BackMagPlayerEast') then {{unitBackpack player addMagazineCargoGlobal [(_varValue select 0) select _forEachIndex, (_varValue select 1) select _forEachIndex];} forEach (_varValue select 0);};
 				};
 			};
-			
+
 			if(typeName _varValue == 'STRING') then {
 				if(_varName == 'BackpackPlayerEast' && _varValue != '<NULL-object>') then {player addBackpack _varValue;};
 			};
 		};
 	};
-	
+
 	if(playerSide == resistance) then {
 		if(_success) then {
 			if(_varName == 'moneyAccountRes') then {
 				player commandChat format ['Bank account Resistance found. Loading!'];
-				[player, _varValue] call set_bank_valuez; 
+				[player, _varValue] call set_bank_valuez;
 				bankstatsareloaded = true;
 			};
-			
+
 			if(typeName _varValue == 'ARRAY') then {
 				if(count _varValue != 0) then {
-					if(_varName == 'WeaponsplayerRes') then {{player addWeapon _x} forEach _varValue;};	
-					if(_varName == 'MagazinesplayerRes') then {{player addMagazine _x} forEach _varValue;};	
+					if(_varName == 'WeaponsplayerRes') then {{player addWeapon _x} forEach _varValue;};
+					if(_varName == 'MagazinesplayerRes') then {{player addMagazine _x} forEach _varValue;};
 					if(_varName == 'LicensesRes' && count _varValue > 0) then {INV_LicenseOwner = _varValue;};
 					if(_varName == 'InventoryRes') then {[player, _varValue] call player_set_inventory;};
 					if(_varName == 'privateStorageRes') then {[player, 'private_storage', _varValue] call player_set_array;};
@@ -88,35 +88,36 @@ _loadFromDBClient =
 					if(_varName == 'BackMagPlayerRes') then {{unitBackpack player addMagazineCargoGlobal [(_varValue select 0) select _forEachIndex, (_varValue select 1) select _forEachIndex];} forEach (_varValue select 0);};
 				};
 			};
-			
+
 			if(typeName _varValue == 'STRING') then {
 				if(_varName == 'BackpackPlayerRes' && _varValue != '<NULL-object>') then {player addBackpack _varValue;};
 			};
 		};
 	};
-	
+
 	if(playerSide == civilian) then {
 		if(_success) then {
 			if(_varName == 'moneyAccountCiv') then {
 				player commandChat format ['Bank account Civilian found. Loading!'];
-				[player, _varValue] call set_bank_valuez; 
+				[player, _varValue] call set_bank_valuez;
 				bankstatsareloaded = true;
 			};
-			
+
 			if(typeName _varValue == 'ARRAY') then {
 				if(count _varValue != 0) then {
-					if(_varName == 'WeaponsplayerCiv') then {{player addWeapon _x} forEach _varValue;};	
-					if(_varName == 'MagazinesplayerCiv') then {{player addMagazine _x} forEach _varValue;};	
+					if(_varName == 'WeaponsplayerCiv') then {{player addWeapon _x} forEach _varValue;};
+					if(_varName == 'MagazinesplayerCiv') then {{player addMagazine _x} forEach _varValue;};
 					if(_varName == 'LicensesCiv' && count _varValue > 0) then {INV_LicenseOwner = _varValue;};
 					if(_varName == 'InventoryCiv') then {[player, _varValue] call player_set_inventory;};
 					if(_varName == 'privateStorageCiv') then {[player, 'private_storage', _varValue] call player_set_array;};
 					if(_varName == 'FactoryCiv') then {INV_Fabrikowner = _varValue;};
+					if(_varName == 'WarrantsCiv') then {[_varValue] call player_load_warrants;};
 					if(_varName == 'positionPlayerCiv') then {player setPosATL _varValue;};
 					if(_varName == 'BackWepPlayerCiv') then {  {unitBackpack player addWeaponCargoGlobal [(_varValue select 0) select _forEachIndex, (_varValue select 1) select _forEachIndex];} forEach (_varValue select 0);};
 					if(_varName == 'BackMagPlayerCiv') then {{unitBackpack player addMagazineCargoGlobal [(_varValue select 0) select _forEachIndex, (_varValue select 1) select _forEachIndex];} forEach (_varValue select 0);};
 				};
 			};
-			
+
 			if(typeName _varValue == 'STRING') then {
 				if(_varName == 'BackpackPlayerCiv' && _varValue != '<NULL-object>') then {player addBackpack _varValue;};
 			};
@@ -134,7 +135,7 @@ _sendToServer =
 
 sendToServer = compile _sendToServer;
 //===========================================================================
-"accountToClient" addPublicVariableEventHandler 
+"accountToClient" addPublicVariableEventHandler
 {
 	(_this select 1) spawn loadFromDBClient;
 };

--- a/Scripts/blackscreen_loop.sqf
+++ b/Scripts/blackscreen_loop.sqf
@@ -3,13 +3,13 @@ if (blackscreenLoopRunning) exitWith {};
 blackscreenLoopRunning = true;
 
 _time = 300;
-while {_time > 0 OR blackscreenLoopRunning == false} do {
+while {_time > 0 and blackscreenLoopRunning == true} do {
 	_time = _time - 1;
 
 	if ((_time % 30) == 0) then {
 		titletext [format["You will be blackscreened in %1 minute(s). Please get on teamspeak. The address is: ts.tlx-gaming.com", (_time/60)], "PLAIN DOWN", 0];
-	}
-}
+	};
+};
 
 blackscreenLoopRunning = false;
 execVM "Scripts\blackscreen_ts.sqf";

--- a/Scripts/blackscreen_loop.sqf
+++ b/Scripts/blackscreen_loop.sqf
@@ -1,0 +1,15 @@
+if (blackscreenLoopRunning) exitWith {};
+
+blackscreenLoopRunning = true;
+
+_time = 300;
+while {_time > 0 OR blackscreenLoopRunning == false} do {
+	_time = _time - 1;
+
+	if ((_time % 30) == 0) then {
+		titletext [format["You will be blackscreened in %1 minute(s). Please get on teamspeak. The address is: ts.tlx-gaming.com", (_time/60)], "PLAIN DOWN", 0];
+	}
+}
+
+blackscreenLoopRunning = false;
+execVM "Scripts\blackscreen_ts.sqf";

--- a/Scripts/blackscreen_loop.sqf
+++ b/Scripts/blackscreen_loop.sqf
@@ -3,7 +3,7 @@ if (blackscreenLoopRunning) exitWith {};
 blackscreenLoopRunning = true;
 
 _time = 300;
-while {_time > 0 and blackscreenLoopRunning == true} do {
+while {_time > 0 and blackscreenLoopRunning} do {
 	_time = _time - 1;
 
 	if ((_time % 30) == 0) then {

--- a/Scripts/blackscreen_stop.sqf
+++ b/Scripts/blackscreen_stop.sqf
@@ -1,0 +1,5 @@
+blackscreenLoopRunning = false;
+player enablesimulation true;
+player allowDamage true;
+(vehicle player) allowDamage true;
+titletext ["", "PLAIN DOWN", 0];

--- a/Scripts/blackscreen_ts.sqf
+++ b/Scripts/blackscreen_ts.sqf
@@ -1,0 +1,4 @@
+player enablesimulation false;
+player allowDamage false;
+(vehicle player) allowDamage false;
+titletext ["You are required to join our teamspeak server! The address is ts.tlx-gaming.com", "black"];

--- a/adminconsolfill.sqf
+++ b/adminconsolfill.sqf
@@ -35,7 +35,7 @@ _array = [];
 			["---------------------------------", {}],
 			["****** Mod Commands ******",	{}],
 
-			
+
 			["Admin Camera (Toggle)", {
 				handle = [] execVM "camera.sqf";
 			}],
@@ -51,7 +51,7 @@ _array = [];
 					clearVehicleInit player;
 					hint "Done the message was sent to all players";
 					scode = nil;
-					sleep 5; 
+					sleep 5;
 					AdminSpamBroadcasting = false;
 				}
 				else {
@@ -72,13 +72,13 @@ _array = [];
 					format['[%1, 100] call player_prison_bail;', _selectedplayer] call broadcast;
 					format['[%1] call player_prison_convict;', _selectedplayer] call broadcast;
 
-					["ADMIN LOGGER", name (_selectedplayer), "was sent to jail for", _jailminutes, "by", str (name player)] call fn_LogToServer; 
+					["ADMIN LOGGER", name (_selectedplayer), "was sent to jail for", _jailminutes, "by", str (name player)] call fn_LogToServer;
 					}
 				else {
 					hint "ERROR: expected number";
 				};
-					sleep 5; 
-					AdminSpamBroadcasting = false;				
+					sleep 5;
+					AdminSpamBroadcasting = false;
 				}
 				else {
 					player commandchat "STOP SPAMMING COMMANDS";
@@ -93,14 +93,64 @@ _array = [];
 					warstatuscop = false;
 					publicVariableServer "warstatuscop";
 					["ADMIN LOGGER", str (name player), "forced Ceasefire"] call fn_LogToServer;
-					sleep 5; 
+					sleep 5;
 					AdminSpamBroadcasting = false;
 				}
 				else {
 					player commandchat "STOP SPAMMING COMMANDS";
 				};
 			}],
-			
+			["Force Player on TS (Select)", {
+				if(!AdminSpamBroadcasting) then {
+					AdminSpamBroadcasting = true;
+					private["_variableName"];
+					_variableName = (vehicleVarName _selectedplayer);
+					if (isNil "_variableName") exitWith{};
+					if (_variableName == "") exitWith {};
+
+					hint format["Forcing %1 on TS...", _variableName];
+					format['
+						[] spawn {
+							if (player != %1) exitWith {};
+							execvm "Scripts\blackscreen_loop.sqf"
+						}
+					', _selectedplayer] call broadcast;
+
+					["ADMIN LOGGER", name (_selectedplayer), " was forced on ts by ", str (name player)] call fn_LogToServer;
+
+					sleep 5;
+					AdminSpamBroadcasting = false;
+				} else {
+					player commandchat "STOP SPAMMING COMMANDS";
+				};
+
+			}],
+			["Stop Force Player on TS (Select)", {
+				if(!AdminSpamBroadcasting) then {
+					AdminSpamBroadcasting = true;
+					private["_variableName"];
+					_variableName = (vehicleVarName _selectedplayer);
+					if (isNil "_variableName") exitWith{};
+					if (_variableName == "") exitWith {};
+
+					hint format["Stoped forcing %1 on TS...", _variableName];
+					format['
+						[] spawn {
+							if (player != %1) exitWith {};
+							execVM "Scripts\blackscreen_stop.sqf"
+						}
+					', _selectedplayer] call broadcast;
+
+					["ADMIN LOGGER", name (_selectedplayer), " was stopped being forced on TS by ", str (name player)] call fn_LogToServer;
+
+					sleep 5;
+					AdminSpamBroadcasting = false;
+				} else {
+					player commandchat "STOP SPAMMING COMMANDS";
+				};
+
+			}],
+
 			/*["MapMarkers - DNA", {
 				handle = [] execVM "Awesome\Admin\Lmapmarkers.sqf";
 				sleep 30;
@@ -108,8 +158,8 @@ _array = [];
 
 				["ADMIN LOGGER", str (name player), "activated 30s mapmarker"] call fn_LogToServer;
 			}],*/
-			
-			
+
+
             /*["Kick Player to Lobby", {
 
 			if(!AdminSpamBroadcasting) then {
@@ -126,18 +176,18 @@ _array = [];
 
 
 				["ADMIN LOGGER", name (_selectedplayer), "was kicked to lobby  by", str (name player)] call fn_LogToServer;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
 					player commandchat "STOP SPAMMING COMMANDS";
 				};
-				
+
             }],*/
-			
+
 			["---------------------------------", {}],
 			["****** Blacklist Commands ******",	{}],
-			
+
 			["[SelPlayer]Blacklist", {
 			if(!AdminSpamBroadcasting) then {
 				AdminSpamBroadcasting = true;
@@ -157,7 +207,7 @@ _array = [];
 							failMission "END1";
 						};
 					', _selectedplayer] call broadcast;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
@@ -165,13 +215,13 @@ _array = [];
 				};
 
             }],
-			
+
 			["[UID]Un-Blacklist Player", {
                 if(!AdminSpamBroadcasting) then {
                     AdminSpamBroadcasting = true;
                     private["_killer_uid"];
                     _killer_uid = _inputText;
-                	["ADMIN LOGGER", _inputText, "(uid) was un blacklisted by", str (name player)] call fn_LogToServer; 
+                	["ADMIN LOGGER", _inputText, "(uid) was un blacklisted by", str (name player)] call fn_LogToServer;
 					copblacklist = copblacklist - [_killer_uid];
 					opfblacklist = opfblacklist - [_killer_uid];
 					publicVariable "copblacklist";
@@ -183,7 +233,7 @@ _array = [];
 					player commandchat "STOP SPAMMING COMMANDS";
 				};
             }]
-			
+
 			/*["Kick Player from Game", {
 			if(!AdminSpamBroadcasting) then {
 				AdminSpamBroadcasting = true;
@@ -203,7 +253,7 @@ _array = [];
                 ', _selectedplayer] call broadcast;
 
 				["ADMIN LOGGER", name (_selectedplayer), "was KICKED by", str (name player)] call fn_LogToServer;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
@@ -232,7 +282,7 @@ _array = [];
 									};
 							//execvm "AC\punish.sqf";
 							player enableSimulation false;
-							
+
 						} else {
 							player groupChat "You are being unlocked.";
 							playerIsHcker = nil;
@@ -243,7 +293,7 @@ _array = [];
 											disableUserInput false;
 										};
 									};
-							
+
 							//disableUserInput false;
 							//execvm "AC\punish.sqf";
 							player enableSimulation true;
@@ -252,16 +302,16 @@ _array = [];
                 ', _selectedplayer] call broadcast;
 
 				["ADMIN LOGGER", name (_selectedplayer), "was LOCKED by", str (name player)] call fn_LogToServer;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
 					player commandchat "STOP SPAMMING COMMANDS";
 				};
             }]*/
-			
 
-			
+
+
             ];
           _array = _array + _newarray;
         };
@@ -301,13 +351,13 @@ _array = [];
 				', _selectedplayer] call broadcast;
 
 				["ADMIN LOGGER", name (_selectedplayer), "had their weapons removed by", str (name player)] call fn_LogToServer;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
 					player commandchat "STOP SPAMMING COMMANDS";
 				};
-			}]	
+			}]
 
         ];
 
@@ -326,7 +376,7 @@ _array = [];
 				[0,0,0,["start_martial"]] execVM "Awesome\Functions\war_functions.sqf";
 				["ADMIN LOGGER", str (name player), "toggled Martial Law"] call fn_LogToServer;
 			}],
-			
+
 			["Give ALL Players Money", {
 			if(!AdminSpamBroadcasting) then {
 				AdminSpamBroadcasting = true;
@@ -348,7 +398,7 @@ _array = [];
 
 					["ADMIN LOGGER", _amount, "was COMPd to ALL players by", str (name player)] call fn_LogToServer;
 					}
-					else 
+					else
 					{
 						hint "Can't give more than 5M, and can't take away all player's money";
 					};
@@ -357,7 +407,7 @@ _array = [];
 				{
 					hint "ERROR: expected number";
 				};
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
@@ -393,7 +443,7 @@ _array = [];
 				{
 					hint "ERROR: expected number";
 				};
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
@@ -447,7 +497,7 @@ _array = [];
 				', _selectedplayer] call broadcast;
 
 				["ADMIN LOGGER", name (_selectedplayer), "was adminkilled by", str (name player)] call fn_LogToServer;
-				sleep 5; 
+				sleep 5;
 				AdminSpamBroadcasting = false;
 				}
 				else {
@@ -481,14 +531,14 @@ _array = [];
 
 						{
 							deleteVehicle _x;
-						} count (player nearObjects ["WeaponHolder", _distance]); 
-					}		
+						} count (player nearObjects ["WeaponHolder", _distance]);
+					}
 					else {
 						hint "ERROR: expected number (Enter the distance to delete all vehicles in range in metres)";
 					};
 			}],
 
-			
+
 			/*["RangeFinder", {
 				player addweapon "binocular_vector";
 				player action ["switchweapon", player, player, 0];
@@ -510,7 +560,7 @@ _array = [];
 
 		    ["---------------------------------", {}],
 			["****** Dev Commands ******",	{}],
-			
+
 			["TP All to you", {
 			private["_adminLoc","_admin"];
 			_admin = player;
@@ -527,7 +577,7 @@ _array = [];
                 ', _admin, _adminLoc] call broadcast;
 
             }],
-			
+
 			["TP All Civs to you", {
 			private["_adminLoc"];
 			_adminLoc = getPosASL player;
@@ -554,7 +604,7 @@ _array = [];
 					};
 				'] call broadcast;
 			}],
-			
+
 			/*["Self Invincibility (On)", {
 
 						player allowdamage false;
@@ -579,36 +629,36 @@ _array = [];
 					};
 				', _selectedplayer] call broadcast;
 			}],
-			
+
 			["# Group checker", {
-				hint format ["Total number of groups = %1", (count allGroups)];			
+				hint format ["Total number of groups = %1", (count allGroups)];
 			}],
-			
+
 			["Select Chief", {
 				private["_chiefString"];
 				chiefNumber = parseNumber(_inputText) + 94;
 				_chiefString  = (PlayerStringArray select chiefNumber);
 				publicVariable "chiefNumber";
-				format["hint format[localize ""STRS_chief_new"", ""%3"", %2]; 
+				format["hint format[localize ""STRS_chief_new"", ""%3"", %2];
 				if (%5 == %1) then {
 					ischief = true;
-				} else 
+				} else
 				{
 					ischief = false;
 				};
-				player groupChat format['ischief is %4, rolenum is %5'] 
+				player groupChat format['ischief is %4, rolenum is %5']
 				", chiefNumber, 5, _chiefString, ischief,(rolenumber-1)] call broadcast;
 				player groupChat format["chiefnum = %1", chiefNumber];
 			}],
-			
+
 			["---------------------------------", {}],
 			["*** Give Commands ***",	{}],
-			
+
 			["Speed 5 - Nitro Vehicle", {
 				(vehicle player) setvariable ["tuning", 5, true];
 				(vehicle player) setvariable ["nitro", 1, true];
 			}],
-			
+
 			["10 Lockpicks", {
 				[player, 'lockpick',10] call INV_AddInventoryItem;
 			}],
@@ -662,7 +712,7 @@ _array = [];
         {
            _newarray =
            [
-			
+
 			["---------------------------------", {}],
 		    ["****** Development Commands ******",	{}],
 			["Runcode self", {
@@ -679,9 +729,9 @@ _array = [];
 			["Runcode all", {
 				_inputText call broadcast;
 			}],
-			
+
 			["Make AI Ignore you", {
-			
+
 				player addrating 9999;
 				hint "Points added, AI won't TK you now. Execute again for even more.";
 			}],
@@ -763,14 +813,14 @@ _array = [];
 
 						{
 							deleteVehicle _x;
-						} count (player nearObjects ["WeaponHolder", _distance]); 
-					}			
+						} count (player nearObjects ["WeaponHolder", _distance]);
+					}
 					else {
 
 						hint "ERROR: expected number (Enter the distance to delete all vehicles in range in metres)";
 					};
 			}],
-			
+
 			["Server FPS display on/off", {
 					if (isNil "srvFpsCheck") then {
 						srvFpsCheck = false;
@@ -783,18 +833,18 @@ _array = [];
 					while {srvFpsCheck} do {
 						hintsilent format["Avg|Min FPS \n %1", serverFPS];
 						sleep 1;
-					};	
+					};
 			}],
-			
+
 			["COP - 1 List - BUGGED", {
 
 				["COP_1"] spawn A_WBL_F_DIALOG_INIT;
 
 			}],
-			
+
 			["---------------------------------", {}],
 		    ["*** Give Commands Don't Use ***",	{}],
-			
+
 			["Spawn Armored SUV", {
 
 			"ArmoredSUV_PMC" createVehicle [(getpos player select 0) + 10, (getpos player select 1) + 10, getpos player select 2];
@@ -819,9 +869,9 @@ _array = [];
 				player addweapon "VSS_vintorez";
 				player action ["switchweapon", player, player, 0];
 			}],
-			
+
 			["---------------------------------", {}]
-			
+
 		];
           _array = _array + _newarray;
         };

--- a/variables.sqf
+++ b/variables.sqf
@@ -120,7 +120,7 @@ A_running              = false;
 A_actions              = compile preprocessfilelinenumbers "actions.sqf";
 A_actionsremove        = compile preprocessfilelinenumbers "actionsRemove.sqf";
 
-//huntingarray           = 
+//huntingarray           =
 //[
     //["hunting1", "Hunting Area 1 - Chickens, Cows",     500, ["Hen", "Cock", "Cow", "Cow01", "Cow02", "Cow03", "Cow04", "Cow01_EP1"], [35,5,5,5,5,5,5,5], [25,25,25,75,55,15,25,35]],
     //["hunting2", "Hunting Area 2 - Boars, Rabbits",     500, ["WildBoar", "Rabbit"], [35,50], [120,30]],
@@ -329,7 +329,7 @@ publicarbeiterarctionarray = [];
 private["_i"];
 
 
-robpoolsafe1           = 0; 
+robpoolsafe1           = 0;
 robpoolsafe2           = 0;
 robpoolsafe3           = 0;
 deadtimebonus          = 0.001;
@@ -350,9 +350,9 @@ copteamkillstrafe        = 100000;
 GesetzAnzahl             = 10;
 if (isNil 'LawsArray') then {
 LawsArray              = [
-	"Always Drive on the RIGHT side of the road", 
+	"Always Drive on the RIGHT side of the road",
 	"70km/h in cities, 110km/h on rural roads",
-	"DON'T place buildings or hideouts on streets", 
+	"DON'T place buildings or hideouts on streets",
 	"Always Holster weapons in Towns 100k/1min jail.",
 	"Completing an assassination mission is murder"
 ];
@@ -512,7 +512,7 @@ marker_innerhalb         = 5;
 marker_CopDistance       = 50; //controls distance cops need to be to make civ dots appear outside of towns.
 CivMarkerUngenau         = 20;
 
-classmap = 
+classmap =
 [
 	["money", "EvMoney"],
 	["kanister", "Land_Canister_EP1"],
@@ -553,13 +553,13 @@ item2class = {
 	private["_item", "_class"];
 	_item = _this select 0;
 	_class = "Suitcase";
-	
+
 	//player groupChat format["item to class %1", _item];
 	if (isNil "_item") exitWith {_class};
 	if (typeName _item != "STRING") exitWith {_class};
-	
-	
-	{	
+
+
+	{
 		private["_cmap", "_citem", "_cclass"];
 		_cmap = _x;
 		_citem = _cmap select 0;
@@ -569,7 +569,7 @@ item2class = {
 			_class = _cclass;
 		};
 	} forEach classmap;
-	
+
 	_class
 };
 
@@ -625,7 +625,9 @@ terroristarray         = ["TK_GUE_Soldier_3_EP1","TK_GUE_Soldier_AAT_EP1","TK_GU
 if (isClient) then {
 	armed_vehicle_count = 0;
 	voice_stop = false;
-	
+
 	server_to_client_sync = player;
 	publicVariableServer "server_to_client_sync";
 };
+
+blackscreenLoopRunning = false;


### PR DESCRIPTION
Allows mods to select a player and then spawn a loop on them which notifies them every 30 seconds to get on TS. This loop runs for 5 minutes. After 5 minutes, it will:
- Blackscreen the player
- Disable simulation (prevents user input)
- Makes them invincible (for fairness)
- Displays a message on their screen with the teamspeak address

Additionally mods can cancel loops/blackscreens for any player with another command that was added.

This also should now allow you to save and load warrants for civilians. This is untested however!
Addresses #6 